### PR TITLE
enforce standards conformance on MSVC and fix warning flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ project(Greeter
 
 # ---- Include guards ----
 
-if(${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
+if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
     message(FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there.")
 endif()
 
@@ -35,17 +35,20 @@ CPMAddPackage(
 
 # ---- Create library ----
 
-# Note: for single header libraries create an interface target instead:
+# Note: for header-only libraries change all PUBLIC flags to INTERFACE and create an interface target:
 # add_library(Greeter INTERFACE)  
 # set_target_properties(Greeter PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_17)
 
 add_library(Greeter ${headers} ${sources})
+
 set_target_properties(Greeter PROPERTIES CXX_STANDARD 17)
+
+# beeing a cross-platform target, we enforce enforce standards conformance on MSVC
+target_compile_options(Greeter PUBLIC "$<$<BOOL:${MSVC}>:/permissive->")
 
 # Link dependencies (if required)
 # target_link_libraries(Greeter PUBLIC cxxopts)
 
-# Note: change PUBLIC to INTERFACE for single header libraries  
 target_include_directories(Greeter
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/source/greeter.cpp
+++ b/source/greeter.cpp
@@ -6,10 +6,7 @@ Greeter::Greeter(std::string _name) : name(_name) {}
 
 std::string Greeter::greet(LanguageCode lang) const {
   switch (lang) {
-#if defined(_WIN32) || defined(WIN32)
-    // this silences a MSVC warning as it does not seem to understand strongly-typed enums
     default:
-#endif
     case LanguageCode::EN:
       return "Hello, " + name + "!";
     case LanguageCode::DE:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,12 +55,12 @@ endif()
 
 ENABLE_TESTING() 
 
-# use doctest_discover_tests for better CTest support
+# Note: doctest and similar testing frameworks can automatically configure CMake tests
+# For other testing frameworks add the tests target instead:
+# ADD_TEST(GreeterTests GreeterTests)
+
 include(${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake)
 doctest_discover_tests(GreeterTests)
-
-# Note: for general testing frameworks use:
-# ADD_TEST(GreeterTests GreeterTests)
 
 # ---- code coverage ----
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,10 +42,13 @@ target_link_libraries(GreeterTests doctest Greeter)
 
 set_target_properties(GreeterTests PROPERTIES CXX_STANDARD 17)
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  target_compile_options(GreeterTests PRIVATE -Wall -pedantic -Wextra -Werror)
-elseif(MSVC)
-  target_compile_options(GreeterTests PRIVATE /W4)
+# enable compiler warnings
+if (NOT TEST_INSTALLED_VERSION)
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    target_compile_options(Greeter PUBLIC -Wall -pedantic -Wextra -Werror)
+  elseif(MSVC)
+    target_compile_options(Greeter PUBLIC /W4)
+  endif()
 endif()
 
 # ---- Add GreeterTests ----
@@ -62,6 +65,6 @@ doctest_discover_tests(GreeterTests)
 # ---- code coverage ----
 
 if (ENABLE_TEST_COVERAGE)
-  set_target_properties(Greeter PROPERTIES CXX_STANDARD 17 COMPILE_FLAGS "-O0 -g -fprofile-arcs -ftest-coverage --coverage")
+  target_compile_options(Greeter PRIVATE -O0 -g -fprofile-arcs -ftest-coverage --coverage)
   target_link_options(Greeter PUBLIC "--coverage")
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,10 +40,12 @@ file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp)
 add_executable(GreeterTests ${sources})
 target_link_libraries(GreeterTests doctest Greeter)
 
+set_target_properties(GreeterTests PROPERTIES CXX_STANDARD 17)
+
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  set_target_properties(GreeterTests PROPERTIES CXX_STANDARD 17 COMPILE_FLAGS "-Wall -pedantic -Wextra -Werror")
-else()
-  set_target_properties(GreeterTests PROPERTIES CXX_STANDARD 17)
+  target_compile_options(GreeterTests PRIVATE -Wall -pedantic -Wextra -Werror)
+elseif(MSVC)
+  target_compile_options(GreeterTests PRIVATE /W4)
 endif()
 
 # ---- Add GreeterTests ----


### PR DESCRIPTION
Previously, when building tests, warning flags were only enabled for the tests target, while they should have been enabled for the library target.