### PR TITLE
Add tools.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,9 @@ if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
     message(FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there.")
 endif()
 
-# ---- Add source files ----
+# --- Import tools ----
 
-# Note: globbing sources is considered bad practice as CMake's generators may not detect new files automatically.
-# Keep that in mind when changing files, or explicitly mention them here.
-FILE(GLOB_RECURSE headers CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h")
-FILE(GLOB_RECURSE sources CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp")
+include(cmake/tools.cmake)
 
 # ---- Add dependencies via CPM ----
 # see https://github.com/TheLartians/CPM.cmake for more info
@@ -32,6 +29,13 @@ CPMAddPackage(
   GITHUB_REPOSITORY TheLartians/PackageProject.cmake
   VERSION 1.0
 )
+
+# ---- Add source files ----
+
+# Note: globbing sources is considered bad practice as CMake's generators may not detect new files automatically.
+# Keep that in mind when changing files, or explicitly mention them here.
+FILE(GLOB_RECURSE headers CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h")
+FILE(GLOB_RECURSE sources CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp")
 
 # ---- Create library ----
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ cmake --build build/test --target fix-format
 
 See [Format.cmake](https://github.com/TheLartians/Format.cmake) for more options.
 
+### Additional tools
+
+The project includes an [tools.cmake](cmake/tools.cmake) file that can be used to import additional tools on-demand through CMake configuration arguments.
+The following are currently supported.
+
+- `-DUSE_SANITIZER=<Address | Memory | MemoryWithOrigins | Undefined | Thread | Leak | 'Address;Undefined'>`
+- `-DUSE_CCACHE=<YES | NO>`
+
+
 ## FAQ
 
 > Can I use this for header-only libraries?

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This template is the result of learnings from many previous projects and should 
 - Code formatting enforced by [clang-format](https://clang.llvm.org/docs/ClangFormat.html) via [Format.cmake](https://github.com/TheLartians/Format.cmake)
 - Reproducible dependency management via [CPM.cmake](https://github.com/TheLartians/CPM.cmake)
 - Installable target with versioning information via [PackageProject.cmake](https://github.com/TheLartians/PackageProject.cmake)
+- Support for [sanitizer tools and more](#additional-tools)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ The following are currently supported.
 - `-DUSE_SANITIZER=<Address | Memory | MemoryWithOrigins | Undefined | Thread | Leak | 'Address;Undefined'>`
 - `-DUSE_CCACHE=<YES | NO>`
 
-
 ## FAQ
 
 > Can I use this for header-only libraries?

--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -1,0 +1,33 @@
+# this file contains a list of tools that can be activated and downloaded on-demand
+# each tool is enabled during configuration by passing an additional `-DUSE_<TOOL>=<VALUE>` argument to CMake
+
+# determine if a tool has already been enabled
+foreach(TOOL USE_SANITIZER;USE_CCACHE)
+  get_property(${TOOL}_ENABLED GLOBAL "" PROPERTY ${TOOL}_ENABLED SET)   
+endforeach()
+
+# enables sanitizers support using the the `USE_SANITIZER` flag
+# available values are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined'
+if (USE_SANITIZER AND NOT USE_SANITIZER_ENABLED)
+  set_property(GLOBAL PROPERTY USE_SANITIZER_ENABLED true) 
+
+  CPMAddPackage(
+    NAME StableCoder-cmake-scripts
+    GITHUB_REPOSITORY StableCoder/cmake-scripts
+    GIT_TAG 3a469d8251660a97dbf9e0afff0a242965d40277
+  )
+  
+  include(${StableCoder-cmake-scripts_SOURCE_DIR}/sanitizers.cmake)
+endif()
+
+# enables CCACHE support through the USE_CCACHE flag
+# possible values are: YES, NO or equivalent
+if (USE_CCACHE AND NOT USE_CCACHE_ENABLED)
+  set_property(GLOBAL PROPERTY USE_CCACHE_ENABLED true) 
+
+  CPMAddPackage(
+    NAME Ccache.cmake
+    GITHUB_REPOSITORY TheLartians/Ccache.cmake
+    VERSION 1.1
+  )
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,14 @@ CPMAddPackage(
   VERSION 1.0
 )
 
+CPMAddPackage(
+  NAME StableCoder-cmake-scripts
+  GITHUB_REPOSITORY StableCoder/cmake-scripts
+  GIT_TAG 3a469d8251660a97dbf9e0afff0a242965d40277
+)
+
+include(${StableCoder-cmake-scripts_SOURCE_DIR}/sanitizers.cmake)
+
 # ---- Create binary ----
 
 file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,8 @@ CPMAddPackage(
   GIT_TAG 3a469d8251660a97dbf9e0afff0a242965d40277
 )
 
+# adds support the the `USE_SANITIZER` flag
+# available options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined'
 include(${StableCoder-cmake-scripts_SOURCE_DIR}/sanitizers.cmake)
 
 # ---- Create binary ----

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,16 +34,6 @@ CPMAddPackage(
   VERSION 1.0
 )
 
-CPMAddPackage(
-  NAME StableCoder-cmake-scripts
-  GITHUB_REPOSITORY StableCoder/cmake-scripts
-  GIT_TAG 3a469d8251660a97dbf9e0afff0a242965d40277
-)
-
-# adds support the the `USE_SANITIZER` flag
-# available options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined'
-include(${StableCoder-cmake-scripts_SOURCE_DIR}/sanitizers.cmake)
-
 # ---- Create binary ----
 
 file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp)


### PR DESCRIPTION
This adds an additional CMake script to the project that adds support for useful tools that can be activated through configuration arguments. Initially supported are:

- `-DUSE_SANITIZER=<Address | Memory | MemoryWithOrigins | Undefined | Thread | Leak | 'Address;Undefined'>`
- `-DUSE_CCACHE=<YES | NO>`
