### PR TITLE
make standalone windows compatible

### DIFF
--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -30,7 +30,6 @@ add_executable(GreeterStandalone ${sources})
 
 set_target_properties(GreeterStandalone PROPERTIES 
   CXX_STANDARD 17 
-  COMPILE_FLAGS "-Wall -pedantic -Wextra"
   OUTPUT_NAME "Greeter"
 )
 


### PR DESCRIPTION
Remove warning flags from standalone target as they only work for clang, gcc compilers