### PR TITLE
Update Format.cmake (windows and out of source build support)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 CPMAddPackage(
   NAME Format.cmake
   GITHUB_REPOSITORY TheLartians/Format.cmake
-  VERSION 1.1
+  VERSION 1.2
 )
 
 # ---- Create binary ----

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 CPMAddPackage(
   NAME Format.cmake
   GITHUB_REPOSITORY TheLartians/Format.cmake
-  VERSION 1.0
+  VERSION 1.1
 )
 
 # ---- Create binary ----


### PR DESCRIPTION
As `grep` isn't available by default in windows, the `check-format` build target [previously failed](https://github.com/TheLartians/Format.cmake/issues/3) on windows systems and builds outside of the git repo.