### PR TITLE
DOCTEST_CONFIG_USE_STD_HEADERS in MSVC++

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,7 @@ if (NOT TEST_INSTALLED_VERSION)
     target_compile_options(Greeter PUBLIC -Wall -pedantic -Wextra -Werror)
   elseif(MSVC)
     target_compile_options(Greeter PUBLIC /W4 /WX)
+    target_compile_definitions(GreeterTests PUBLIC DOCTEST_CONFIG_USE_STD_HEADERS)
   endif()
 endif()
 

--- a/test/source/greeter.cpp
+++ b/test/source/greeter.cpp
@@ -3,7 +3,7 @@
 
 #if defined(_WIN32) || defined(WIN32)
 // apparently this is required to compile in MSVC++
-#  include <sstream>
+#  include <ostream>
 #endif
 
 TEST_CASE("Greeter") {

--- a/test/source/greeter.cpp
+++ b/test/source/greeter.cpp
@@ -1,10 +1,9 @@
+#if defined(_WIN32) || defined(WIN32)
+#  define DOCTEST_CONFIG_USE_STD_HEADERS
+#endif
+
 #include <doctest/doctest.h>
 #include <greeter.h>
-
-#if defined(_WIN32) || defined(WIN32)
-// apparently this is required to compile in MSVC++
-#  include <ostream>
-#endif
 
 TEST_CASE("Greeter") {
   using namespace greeter;

--- a/test/source/greeter.cpp
+++ b/test/source/greeter.cpp
@@ -1,7 +1,3 @@
-#if defined(_WIN32) || defined(WIN32)
-#  define DOCTEST_CONFIG_USE_STD_HEADERS
-#endif
-
 #include <doctest/doctest.h>
 #include <greeter.h>
 


### PR DESCRIPTION
It seems there's no need to include whole `<sstream>` header. Just `<ostream>` is enough.