### PR TITLE
enable local actions for pull requests

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,6 @@
 name: Install
 
-on: [push]
+on: [push, pull_request]
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,6 @@
 name: MacOS
 
-on: [push]
+on: [push, pull_request]
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -1,6 +1,6 @@
 name: Standalone
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,6 +1,6 @@
 name: Style
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,6 +1,6 @@
 name: Ubuntu
 
-on: [push]
+on: [push, pull_request]
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,6 @@
 name: Windows
 
-on: [push]
+on: [push, pull_request]
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1


### PR DESCRIPTION
It seems we can run GitHub Actions on pull requests, even if the fork itself has not yet activated actions (they appear to be off by default for forks). Still want to figure out if this could theoretically compromise repository secrets before merging.

Additional information:

- https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request

Edit: seems secrets are kept: https://www.edwardthomson.com/blog/github_actions_11_secrets.html