### PR TITLE
Only apply tools for top-level directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,6 @@ if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
     message(FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there.")
 endif()
 
-# --- Import tools ----
-
-include(cmake/tools.cmake)
-
 # ---- Add dependencies via CPM ----
 # see https://github.com/TheLartians/CPM.cmake for more info
 

--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -1,16 +1,16 @@
 # this file contains a list of tools that can be activated and downloaded on-demand
 # each tool is enabled during configuration by passing an additional `-DUSE_<TOOL>=<VALUE>` argument to CMake
 
-# determine if a tool has already been enabled
-foreach(TOOL USE_SANITIZER;USE_CCACHE)
-  get_property(${TOOL}_ENABLED GLOBAL "" PROPERTY ${TOOL}_ENABLED SET)   
-endforeach()
+# only activate tools for top level project
+if (NOT PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  return()
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
 
 # enables sanitizers support using the the `USE_SANITIZER` flag
 # available values are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined'
-if (USE_SANITIZER AND NOT USE_SANITIZER_ENABLED)
-  set_property(GLOBAL PROPERTY USE_SANITIZER_ENABLED true) 
-
+if (USE_SANITIZER)
   CPMAddPackage(
     NAME StableCoder-cmake-scripts
     GITHUB_REPOSITORY StableCoder/cmake-scripts
@@ -22,9 +22,7 @@ endif()
 
 # enables CCACHE support through the USE_CCACHE flag
 # possible values are: YES, NO or equivalent
-if (USE_CCACHE AND NOT USE_CCACHE_ENABLED)
-  set_property(GLOBAL PROPERTY USE_CCACHE_ENABLED true) 
-
+if (USE_CCACHE)
   CPMAddPackage(
     NAME Ccache.cmake
     GITHUB_REPOSITORY TheLartians/Ccache.cmake

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -4,6 +4,10 @@ project(GreeterStandalone
   LANGUAGES CXX
 )
 
+# --- Import tools ----
+
+include(../cmake/tools.cmake)
+
 # ---- Dependencies ----
 
 include(../cmake/CPM.cmake)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,10 @@ project(GreeterTests
 option(ENABLE_TEST_COVERAGE "Enable test coverage" OFF)
 option(TEST_INSTALLED_VERSION "Test the version found by find_package" OFF)
 
+# --- Import tools ----
+
+include(../cmake/tools.cmake)
+
 # ---- Dependencies ----
 
 include(../cmake/CPM.cmake)


### PR DESCRIPTION
Disables tools when not imported from top-level directory. This fixes unexpected behaviour and possible linker errors when using sanitisers from derived projects.
Also updates CPM.cmake to a recent version.