### PR TITLE
add proper include guard to tools

### DIFF
--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -1,10 +1,7 @@
 # this file contains a list of tools that can be activated and downloaded on-demand each tool is
 # enabled during configuration by passing an additional `-DUSE_<TOOL>=<VALUE>` argument to CMake
 
-# only activate tools for top level project
-if(NOT PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  return()
-endif()
+include_guard(DIRECTORY)
 
 include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
 


### PR DESCRIPTION
With the current structure, we don't need the top level project restriction anymore, as the tools are only included by non-library subprojects.