### PR TITLE
Use official m.css repo

### DIFF
--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -11,9 +11,8 @@ CPMAddPackage(NAME Greeter SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
 CPMAddPackage(
   NAME MCSS
   DOWNLOAD_ONLY YES
-  # patched version until https://github.com/mosra/m.css/pull/171 is resolved
-  GITHUB_REPOSITORY TheLartians/m.css
-  GIT_TAG 1bf162b96d5bfefc9967a80cef138f1270ffa415
+  GITHUB_REPOSITORY mosra/m.css
+  GIT_TAG 42d4a9a48f31f5df6e246c948403b54b50574a2a
 )
 
 # ---- Doxygen variables ----


### PR DESCRIPTION
As it seems that the error which lead to the creation of my fork [no longer occurs](https://github.com/mosra/m.css/pull/171), we can switch to the official repo for the m.css style.