### PR TITLE
use namespaced target

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -48,6 +48,7 @@ parse:
       kwargs:
         NAME: 1
         VERSION: 1
+        NAMESPACE: 1
         INCLUDE_DIR: 1
         INCLUDE_DESTINATION: 1
         BINARY_DIR: 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ include(cmake/CPM.cmake)
 CPMAddPackage(
   NAME PackageProject.cmake
   GITHUB_REPOSITORY TheLartians/PackageProject.cmake
-  VERSION 1.3
+  VERSION 1.4
 )
 
 # ---- Add source files ----
@@ -67,6 +67,7 @@ string(TOLOWER ${PROJECT_NAME}/version.h VERSION_HEADER_LOCATION)
 packageProject(
   NAME ${PROJECT_NAME}
   VERSION ${PROJECT_VERSION}
+  NAMESPACE ${PROJECT_NAME}
   BINARY_DIR ${PROJECT_BINARY_DIR}
   INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include
   INCLUDE_DESTINATION include/${PROJECT_NAME}-${PROJECT_VERSION}

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -27,4 +27,4 @@ add_executable(GreeterStandalone ${sources})
 
 set_target_properties(GreeterStandalone PROPERTIES CXX_STANDARD 17 OUTPUT_NAME "Greeter")
 
-target_link_libraries(GreeterStandalone Greeter cxxopts)
+target_link_libraries(GreeterStandalone Greeter::Greeter cxxopts)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,7 +39,7 @@ CPMAddPackage(
 
 file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp)
 add_executable(GreeterTests ${sources})
-target_link_libraries(GreeterTests doctest Greeter)
+target_link_libraries(GreeterTests doctest Greeter::Greeter)
 
 set_target_properties(GreeterTests PROPERTIES CXX_STANDARD 17)
 


### PR DESCRIPTION
Moves the library target into a namespace using PackageProject's new [namespace support](https://github.com/TheLartians/PackageProject.cmake/pull/10). This has the advantage of [discovering invalid targets](https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html?highlight=namespace) at configure time.