### PR TITLE
add cpm_modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build*
 /.vscode
+/cpm_modules
 .DS_Store


### PR DESCRIPTION
The modules directory is used by the new cached workflows.