### PR TITLE
Update CPM.cmake and use new shorthand syntax

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,17 +24,13 @@ endif()
 include(cmake/CPM.cmake)
 
 # PackageProject.cmake will be used to make our target installable
-CPMAddPackage(
-  NAME PackageProject.cmake
-  GITHUB_REPOSITORY TheLartians/PackageProject.cmake
-  VERSION 1.5.0
-)
+CPMAddPackage("gh:TheLartians/PackageProject.cmake@1.4.1")
 
 CPMAddPackage(
   NAME fmt
   GIT_TAG 7.1.3
-  GITHUB_REPOSITORY fmtlib/fmt # to get an installable target
-  OPTIONS "FMT_INSTALL YES"
+  GITHUB_REPOSITORY fmtlib/fmt
+  OPTIONS "FMT_INSTALL YES" # create an installable target
 )
 
 # ---- Add source files ----

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,4 +1,4 @@
-set(CPM_DOWNLOAD_VERSION 0.28.4)
+set(CPM_DOWNLOAD_VERSION 0.31.0)
 
 if(CPM_SOURCE_CACHE)
   # Expand relative path. This is important if the provided path contains a tilde (~)

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -10,12 +10,7 @@ include(../cmake/tools.cmake)
 
 include(../cmake/CPM.cmake)
 
-CPMAddPackage(
-  NAME cxxopts
-  GITHUB_REPOSITORY jarro2783/cxxopts
-  VERSION 2.2.0
-  OPTIONS "CXXOPTS_BUILD_EXAMPLES Off" "CXXOPTS_BUILD_TESTS Off"
-)
+CPMAddPackage("gh:jarro2783/cxxopts@2.2.0")
 
 CPMAddPackage(NAME Greeter SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,11 +15,7 @@ include(../cmake/tools.cmake)
 
 include(../cmake/CPM.cmake)
 
-CPMAddPackage(
-  NAME doctest
-  GITHUB_REPOSITORY onqtam/doctest
-  GIT_TAG 2.4.5
-)
+CPMAddPackage("gh:onqtam/doctest#2.4.5")
 
 if(TEST_INSTALLED_VERSION)
   find_package(Greeter REQUIRED)


### PR DESCRIPTION
Uses the new [shorthand syntax](https://github.com/cpm-cmake/CPM.cmake/releases/tag/v0.31.0) introduced in CPM.cmake 0.31.0, where possible. Also temporarily falls back to PackageProject 1.4.1, until a fix is available for a small [bug](https://github.com/TheLartians/PackageProject.cmake/issues/21) introduced in 1.5.0.