### PR TITLE
formatting updates

### DIFF
--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -10,8 +10,12 @@ include(../cmake/tools.cmake)
 
 include(../cmake/CPM.cmake)
 
-option(CXXOPTS_BUILD_TESTS "" NO)
-CPMAddPackage("gh:jarro2783/cxxopts@2.2.0")
+CPMAddPackage(
+  GITHUB_REPOSITORY jarro2783/cxxopts
+  VERSION 2.2.0
+  OPTIONS "CXXOPTS_BUILD_TESTS NO"
+)
+
 CPMAddPackage(NAME Greeter SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
 
 # ---- Create standalone executable ----

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,14 +16,13 @@ include(../cmake/tools.cmake)
 include(../cmake/CPM.cmake)
 
 CPMAddPackage("gh:onqtam/doctest#2.4.5")
+CPMAddPackage("gh:TheLartians/Format.cmake@1.7.0")
 
 if(TEST_INSTALLED_VERSION)
   find_package(Greeter REQUIRED)
 else()
   CPMAddPackage(NAME Greeter SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
 endif()
-
-CPMAddPackage("gh:TheLartians/Format.cmake@1.7.0")
 
 # ---- Create binary ----
 


### PR DESCRIPTION
- Bundles `CPMAddPackage` calls 
- Moves the `CXXOPTS_BUILD_TESTS` option into an explicit `CPMAddPackage` call. This enables additional consistency checks and makes the intent more obvious.