### PR TITLE
Update README.md to use -S/-B per `cmake --help`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ During development it is usually convenient to [build all subprojects at once](#
 Use the following command to build and run the executable target.
 
 ```bash
-cmake -Hstandalone -Bbuild/standalone
+cmake -S standalone -B build/standalone
 cmake --build build/standalone
 ./build/standalone/Greeter --help
 ```
@@ -62,7 +62,7 @@ cmake --build build/standalone
 Use the following commands from the project's root directory to run the test suite.
 
 ```bash
-cmake -Htest -Bbuild/test
+cmake -S test -B build/test
 cmake --build build/test
 CTEST_OUTPUT_ON_FAILURE=1 cmake --build build/test --target test
 
@@ -78,7 +78,7 @@ Use the following commands from the project's root directory to check and fix C+
 This requires _clang-format_, _cmake-format_ and _pyyaml_ to be installed on the current system.
 
 ```bash
-cmake -Htest -Bbuild/test
+cmake -S test -B build/test
 
 # view changes
 cmake --build build/test --target format
@@ -95,7 +95,7 @@ The documentation is automatically built and [published](https://thelartians.git
 To manually build documentation, call the following command.
 
 ```bash
-cmake -Hdocumentation -Bbuild/doc
+cmake -S documentation -B build/doc
 cmake --build build/doc --target GenerateDocs
 # view the docs
 open build/doc/doxygen/html/index.html
@@ -109,7 +109,7 @@ The project also includes an `all` directory that allows building all targets at
 This is useful during development, as it exposes all subprojects to your IDE and avoids redundant builds of the library.
 
 ```bash
-cmake -Hall -Bbuild
+cmake -S all -B build
 cmake --build build
 
 # run tests


### PR DESCRIPTION
-S and -B were added in CMake 3.13. `cmake -Hsource_dir` is undocumented
and `cmake -H` is documented to show the cmake help message. This change
should help newcomers better understand the cmake invocations presented
in the README.md. It also adds the space between the option and the
argument, which is purely stylistic but is consistent with the cmake
documentation.