### PR TITLE
Lock clang-format version

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -26,9 +26,7 @@ jobs:
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
 
       - name: Install format dependencies
-        run: |
-          brew install clang-format
-          pip3 install cmake_format==0.6.11 pyyaml
+        run: pip3 install clang-format==14.0.6 cmake_format==0.6.11 pyyaml
 
       - name: configure
         run: cmake -Stest -Bbuild

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ cmake --build build/test --target fix-format
 ```
 
 See [Format.cmake](https://github.com/TheLartians/Format.cmake) for details.
+These dependencies can be easily installed using pip.
+
+```bash
+pip install clang-format==14.0.6 cmake_format==0.6.11 pyyaml
+```
 
 ### Build the documentation
 


### PR DESCRIPTION
This makes clang-format corrections more predictable, as the version is now locked in the workflow.
Also we can now use the ubuntu runner for the workflow as the installation is platform independent.