### PR TITLE
Upgrade fmt version from 9.1.0 to 10.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ CPMAddPackage("gh:TheLartians/PackageProject.cmake@1.8.0")
 
 CPMAddPackage(
   NAME fmt
-  GIT_TAG 9.1.0
+  GIT_TAG 10.2.1
   GITHUB_REPOSITORY fmtlib/fmt
   OPTIONS "FMT_INSTALL YES" # create an installable target
 )


### PR DESCRIPTION
Basically, fmt on 9.1.0 produces a lot of errors on the windows ci context.

For example: 

```
D:\a\dist\dist\cpm_modules\fmt\5c4bc51f3df5bb907a0028facff05ba4978aa6e5\include\fmt\format.h(490,51): 
    warning C4996: 'stdext::checked_array_iterator<T*>': warning STL4043: stdext::checked_array_iterator, stdext::unchecked_array_iterator, and related factory functions are non-Standard extensions and will be removed in the future. std::span (since C++20) and gsl::span can be used instead. You can define _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING or _SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS to suppress this warning. [D:\a\dist\dist\build\_deps\worker-build\Worker.vcxproj]
  (compiling source file '../../../source/worker.cpp')
  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\iterator(1470,1):
  see declaration of 'stdext::checked_array_iterator'
```

By the way, as there are not `_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS` defined, all the warnings are treated as error.

I discover this issue by fork this starter kit and implement as a base for my own project. 

![image](https://github.com/TheLartians/ModernCppStarter/assets/111059524/6f6f3167-18af-4d30-920f-9e819524f275)

The following **[logs](https://github.com/zen-is/dist/actions/runs/7993836899/job/21830519832)** includes the relevant messages and, of course, was solved by an upgrade of FMT.

Anyways, thanks a lot @TheLartians.